### PR TITLE
refactor: Implement on-demand data source connections and standardize…

### DIFF
--- a/src/main/java/com/example/exsql/controller/SqlUploadController.java
+++ b/src/main/java/com/example/exsql/controller/SqlUploadController.java
@@ -13,9 +13,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import java.util.Arrays;
+import com.example.exsql.model.DataSourceDefinition; // Added import
+import java.util.Arrays; // Keep if still needed for other parts, or remove if not
 import java.util.Collections;
 import java.util.List;
+import java.util.Map; // Added import
+import java.util.Set; // Added import
 import java.util.stream.Collectors;
 
 @Controller
@@ -23,8 +26,14 @@ public class SqlUploadController {
 
     private static final Logger logger = LoggerFactory.getLogger(SqlUploadController.class);
 
+    private final SqlExecutionService sqlExecutionService;
+    private final Map<String, DataSourceDefinition> dataSourceDefinitions;
+
     @Autowired
-    private SqlExecutionService sqlExecutionService;
+    public SqlUploadController(SqlExecutionService sqlExecutionService, Map<String, DataSourceDefinition> dataSourceDefinitions) {
+        this.sqlExecutionService = sqlExecutionService;
+        this.dataSourceDefinitions = dataSourceDefinitions;
+    }
 
     @GetMapping("/")
     public String uploadPage(Model model) {
@@ -38,8 +47,10 @@ public class SqlUploadController {
          if (!model.containsAttribute("successMessage")) {
             model.addAttribute("successMessage", null);
         }
-        // Add data source names for the UI
-        model.addAttribute("dataSourceNames", Arrays.asList("primary", "secondary"));
+        // Add data source names from the keys of the dataSourceDefinitions map
+        Set<String> dsNames = dataSourceDefinitions.keySet();
+        logger.info("Available data source names for UI: {}", dsNames);
+        model.addAttribute("dataSourceNames", dsNames);
         return "upload";
     }
 

--- a/src/main/java/com/example/exsql/model/DataSourceDefinition.java
+++ b/src/main/java/com/example/exsql/model/DataSourceDefinition.java
@@ -1,0 +1,53 @@
+package com.example.exsql.model;
+
+public class DataSourceDefinition {
+
+    private String name;
+    private String url;
+    private String username;
+    private String driverClassName;
+    private String cndlAuthFilePath;
+    private int cndlNdbType;
+    private String cndlTns;
+    private String cndlGetPasswdUrl;
+    private String cndlGetPasswdDummyPassword;
+    private String httpPasswordUrl; // Optional, only for primary in current setup
+    private int httpPasswordRequestTimeoutMs; // Optional
+
+    // Constructor
+    public DataSourceDefinition(String name, String url, String username, String driverClassName,
+                                String cndlAuthFilePath, int cndlNdbType, String cndlTns,
+                                String cndlGetPasswdUrl, String cndlGetPasswdDummyPassword) {
+        this.name = name;
+        this.url = url;
+        this.username = username;
+        this.driverClassName = driverClassName;
+        this.cndlAuthFilePath = cndlAuthFilePath;
+        this.cndlNdbType = cndlNdbType;
+        this.cndlTns = cndlTns;
+        this.cndlGetPasswdUrl = cndlGetPasswdUrl;
+        this.cndlGetPasswdDummyPassword = cndlGetPasswdDummyPassword;
+    }
+
+    // Getters
+    public String getName() { return name; }
+    public String getUrl() { return url; }
+    public String getUsername() { return username; }
+    public String getDriverClassName() { return driverClassName; }
+    public String getCndlAuthFilePath() { return cndlAuthFilePath; }
+    public int getCndlNdbType() { return cndlNdbType; }
+    public String getCndlTns() { return cndlTns; }
+    public String getCndlGetPasswdUrl() { return cndlGetPasswdUrl; }
+    public String getCndlGetPasswdDummyPassword() { return cndlGetPasswdDummyPassword; }
+    public String getHttpPasswordUrl() { return httpPasswordUrl; }
+    public int getHttpPasswordRequestTimeoutMs() { return httpPasswordRequestTimeoutMs; }
+
+    // Setters for optional HTTP password fields
+    public void setHttpPasswordUrl(String httpPasswordUrl) {
+        this.httpPasswordUrl = httpPasswordUrl;
+    }
+
+    public void setHttpPasswordRequestTimeoutMs(int httpPasswordRequestTimeoutMs) {
+        this.httpPasswordRequestTimeoutMs = httpPasswordRequestTimeoutMs;
+    }
+}

--- a/src/main/java/com/example/exsql/service/SqlExecutionService.java
+++ b/src/main/java/com/example/exsql/service/SqlExecutionService.java
@@ -1,18 +1,23 @@
 package com.example.exsql.service;
 
+import com.example.exsql.model.DataSourceDefinition;
 import com.example.exsql.model.ScriptExecutionResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.sql.DataSource;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -20,43 +25,91 @@ public class SqlExecutionService {
 
     private static final Logger logger = LoggerFactory.getLogger(SqlExecutionService.class);
 
-    private final JdbcTemplate primaryJdbcTemplate;
-    private final JdbcTemplate secondaryJdbcTemplate;
+    private final Map<String, DataSourceDefinition> dataSourceDefinitions;
+    private final CustomPasswordRetrievalService passwordRetrievalService;
 
     @Autowired
-    public SqlExecutionService(JdbcTemplate jdbcTemplate,
-                               @org.springframework.beans.factory.annotation.Qualifier("dataSource2") javax.sql.DataSource dataSource2) {
-        this.primaryJdbcTemplate = jdbcTemplate; // This is the default JdbcTemplate from the primary DataSource
-        this.secondaryJdbcTemplate = new JdbcTemplate(dataSource2);
+    public SqlExecutionService(Map<String, DataSourceDefinition> dataSourceDefinitions,
+                               CustomPasswordRetrievalService passwordRetrievalService) {
+        this.dataSourceDefinitions = dataSourceDefinitions;
+        this.passwordRetrievalService = passwordRetrievalService;
     }
 
     public List<ScriptExecutionResult> executeSqlScripts(MultipartFile[] files, String dataSourceName) {
         List<ScriptExecutionResult> results = new ArrayList<>();
-        JdbcTemplate selectedJdbcTemplate;
+        
+        String effectiveDataSourceName = (dataSourceName == null || dataSourceName.trim().isEmpty()) ? "primary" : dataSourceName.toLowerCase();
+        logger.info("Attempting to execute scripts on data source: {}", effectiveDataSourceName);
 
-        if ("secondary".equalsIgnoreCase(dataSourceName)) {
-            selectedJdbcTemplate = secondaryJdbcTemplate;
-            logger.info("Executing scripts on secondary data source.");
-        } else if ("primary".equalsIgnoreCase(dataSourceName) || dataSourceName == null || dataSourceName.isEmpty()) {
-            selectedJdbcTemplate = primaryJdbcTemplate;
-            logger.info("Executing scripts on primary data source.");
-        } else {
-            logger.error("Invalid data source name provided: {}", dataSourceName);
-            // Handle invalid data source name, perhaps by returning an error for all files
-            // or throwing an IllegalArgumentException. For now, log and skip execution.
+        DataSourceDefinition definition = dataSourceDefinitions.get(effectiveDataSourceName);
+
+        if (definition == null) {
+            logger.error("Data source definition not found for name: {}", effectiveDataSourceName);
             for (MultipartFile file : files) {
-                results.add(new ScriptExecutionResult(file.getOriginalFilename(), false, "Invalid data source name: " + dataSourceName, ""));
+                results.add(new ScriptExecutionResult(file.getOriginalFilename(), false, "Data source definition not found: " + effectiveDataSourceName, ""));
             }
             return results;
         }
 
+        logger.info("Found data source definition for: {}", definition.getName());
+        String password;
+        try {
+            if ("primary".equals(definition.getName())) {
+                 logger.info("Retrieving password for primary data source using its specific CNLDB/HTTP mechanism.");
+                 // This relies on CustomPasswordRetrievalService.retrievePrimaryPassword using its own @Value injected CNLDB params.
+                 // If primary also had HTTP password definition, that logic would be inside retrievePrimaryPassword or called from here.
+                password = passwordRetrievalService.retrievePrimaryPassword(definition.getUsername());
+            } else {
+                logger.info("Retrieving password for data source '{}' using CNLDB parameters from its definition.", definition.getName());
+                password = passwordRetrievalService.retrievePassword(
+                        definition.getUsername(),
+                        definition.getCndlNdbType(),
+                        definition.getCndlTns(),
+                        definition.getCndlGetPasswdUrl(),
+                        definition.getCndlGetPasswdDummyPassword(),
+                        definition.getName()
+                );
+            }
+            if (!StringUtils.hasText(password)) {
+                 logger.error("Retrieved password was empty for data source: {}", definition.getName());
+                 throw new RuntimeException("Retrieved password was empty for data source " + definition.getName() + ".");
+            }
+            logger.info("Password retrieved successfully for data source: {}", definition.getName());
+        } catch (Exception e) {
+            logger.error("Failed to retrieve password for data source {}: {}", definition.getName(), e.getMessage(), e);
+            for (MultipartFile file : files) {
+                results.add(new ScriptExecutionResult(file.getOriginalFilename(), false, "Failed to retrieve password for data source " + definition.getName() + ": " + e.getMessage(), ""));
+            }
+            return results;
+        }
+
+        DataSource dynamicDataSource;
+        try {
+            dynamicDataSource = DataSourceBuilder.create()
+                    .url(definition.getUrl())
+                    .username(definition.getUsername())
+                    .password(password)
+                    .driverClassName(definition.getDriverClassName())
+                    .build();
+            logger.info("Dynamically created DataSource for: {}", definition.getName());
+        } catch (Exception e) {
+            logger.error("Failed to create DataSource for {}: {}", definition.getName(), e.getMessage(), e);
+            for (MultipartFile file : files) {
+                results.add(new ScriptExecutionResult(file.getOriginalFilename(), false, "Failed to create DataSource for " + definition.getName() + ": " + e.getMessage(), ""));
+            }
+            return results;
+        }
+        
+        JdbcTemplate jdbcTemplate = new JdbcTemplate(dynamicDataSource);
+        logger.info("JdbcTemplate created for data source: {}", definition.getName());
+
         for (MultipartFile file : files) {
-            results.add(executeSingleScript(file, selectedJdbcTemplate));
+            results.add(executeSingleScript(file, jdbcTemplate, definition.getName()));
         }
         return results;
     }
 
-    private ScriptExecutionResult executeSingleScript(MultipartFile file, JdbcTemplate jdbcTemplate) {
+    private ScriptExecutionResult executeSingleScript(MultipartFile file, JdbcTemplate jdbcTemplate, String dataSourceName) {
         String fileName = file.getOriginalFilename();
         String sqlContent = null;
         try {
@@ -77,9 +130,7 @@ public class SqlExecutionService {
             // Trim leading/trailing whitespace from the whole script
             sqlContent = sqlContent.trim();
 
-            logger.info("Executing script: {} using {}. Content length: {}", fileName, 
-                (jdbcTemplate == primaryJdbcTemplate ? "primary" : "secondary") + " JdbcTemplate", 
-                sqlContent.length());
+            logger.info("Executing script: {} on data source: {}. Content length: {}", fileName, dataSourceName, sqlContent.length());
 
             // Determine execution type (simple heuristic)
             boolean isPlSqlBlock = sqlContent.toUpperCase().contains("DECLARE") ||
@@ -87,11 +138,11 @@ public class SqlExecutionService {
                                    sqlContent.trim().endsWith("/");
 
             if (isPlSqlBlock) {
-                logger.info("Detected PL/SQL block for file: {}", fileName);
+                logger.info("Detected PL/SQL block for file: {} on data source: {}", fileName, dataSourceName);
                 jdbcTemplate.execute(sqlContent);
-                return new ScriptExecutionResult(fileName, true, "PL/SQL block executed successfully.", sqlContent);
+                return new ScriptExecutionResult(fileName, true, "PL/SQL block executed successfully on " + dataSourceName + ".", sqlContent);
             } else {
-                logger.info("Detected plain SQL statements for file: {}", fileName);
+                logger.info("Detected plain SQL statements for file: {} on data source: {}", fileName, dataSourceName);
                 String[] statements = sqlContent.split(";(?=(?:[^']*'[^']*')*[^']*$)"); // Split by semicolon, ignoring those inside quotes
                 
                 int executedCount = 0;
@@ -99,20 +150,20 @@ public class SqlExecutionService {
                     String trimmedStmt = stmt.trim();
                     if (!trimmedStmt.isEmpty()) {
                         try {
-                           logger.debug("Executing statement: {}", trimmedStmt);
+                           logger.debug("Executing statement on {}: {}", dataSourceName, trimmedStmt);
                            jdbcTemplate.execute(trimmedStmt);
                            executedCount++;
                         } catch (Exception e) {
-                            logger.error("Error executing statement in file {}: {}\nStatement: {}", fileName, e.getMessage(), trimmedStmt, e);
-                            return new ScriptExecutionResult(fileName, false, "Error executing statement: " + e.getMessage() + "\nProblematic statement: " + trimmedStmt, sqlContent);
+                            logger.error("Error executing statement in file {} on data source {}: {}\nStatement: {}", fileName, dataSourceName, e.getMessage(), trimmedStmt, e);
+                            return new ScriptExecutionResult(fileName, false, "Error on " + dataSourceName + ": " + e.getMessage() + "\nProblematic statement: " + trimmedStmt, sqlContent);
                         }
                     }
                 }
-                return new ScriptExecutionResult(fileName, true, executedCount + " plain SQL statement(s) executed successfully.", sqlContent);
+                return new ScriptExecutionResult(fileName, true, executedCount + " plain SQL statement(s) executed successfully on " + dataSourceName + ".", sqlContent);
             }
         } catch (Exception e) {
-            logger.error("Failed to execute script: {}. Error: {}", fileName, e.getMessage(), e);
-            return new ScriptExecutionResult(fileName, false, "Failed to execute script: " + e.getMessage(), sqlContent != null ? sqlContent : "Could not read content");
+            logger.error("Failed to execute script: {} on data source: {}. Error: {}", fileName, dataSourceName, e.getMessage(), e);
+            return new ScriptExecutionResult(fileName, false, "Failed to execute script on " + dataSourceName + ": " + e.getMessage(), sqlContent != null ? sqlContent : "Could not read content");
         }
     }
 } 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,48 +1,57 @@
-# DataSource settings
-spring.datasource.url=jdbc:oceanbase:loadbalance//10.32.30.201:2883,10.32.30.203:2883/bosspub?continueBatchOnError=false&useServerPrepStmts=false&allowMultiQueries=true&rewriteBatchedStatements=true&loadBalanceStrategy=RANDOM
-spring.datasource.username=bosspub@palldb#biadb_arm
-# spring.datasource.password=your_password # Password will be fetched dynamically via CNLDBConnectMgr
-spring.datasource.driver-class-name=com.oceanbase.jdbc.Driver
-
-# CNLDBConnectMgr Configuration
-# IMPORTANT: You must create this file and provide correct values for appCheckCode, appName, and url (UIG Server URL)
-app.datasource.cndl.auth-file-path=classpath:cndl-auth.properties # Example: classpath:cndl-auth.properties or file:/path/to/cndl-auth.properties
-app.datasource.cndl.ndbtype=2
-app.datasource.cndl.tns=palldb
-# The 'url' parameter for CNLDBConnectMgr.getPasswd(..., url, ...)
-# This is potentially different from the UIG server URL in cndl-auth.properties, or might be ignored if serverUrl is always used.
-# Provide the correct value if it's used by your actual CNLDBConnectMgr for something specific.
-app.datasource.cndl.getpasswd-url=jdbc:oceanbase:loadbalance//10.32.30.201:2883,10.32.30.203:2883/bosspub?continueBatchOnError=false&useServerPrepStmts=false&allowMultiQueries=true&rewriteBatchedStatements=true&loadBalanceStrategy=RANDOM
-# The 'passwd' (dummyPassword) parameter for CNLDBConnectMgr.getPasswd(..., passwd)
-app.datasource.cndl.getpasswd-dummy-password=75Ym2BOflT5BeusEo2qDMw==
-
-# Dynamic Password Retrieval Configuration
-app.datasource.password-url=YOUR_HTTP_ENDPOINT_FOR_PASSWORD_HERE # <<< IMPORTANT: Configure this URL
-app.datasource.password-request.timeout-ms=5000 # Timeout in milliseconds for the password request
+# ===================================================================
+# General Application Settings
+# ===================================================================
+# Server port (default is 8080)
+server.port=8283
 
 # Thymeleaf settings
-spring.thymeleaf.cache=false
-# Disable caching for development for the line above
+spring.thymeleaf.cache=false # Disable caching for development for optimal template reloading.
 spring.thymeleaf.prefix=classpath:/templates/
 spring.thymeleaf.suffix=.html
 
 # Multipart file upload settings
 spring.servlet.multipart.max-file-size=10MB
-spring.servlet.multipart.max-request-size=100MB
-# Max total size for a multipart request for the line above
+spring.servlet.multipart.max-request-size=100MB # Maximum total size for a multipart request.
 
-# Server port (optional, default is 8080)
-server.port=8283
+# ===================================================================
+# Primary Data Source Configuration (Default)
+# ===================================================================
+# Standard Spring Boot JDBC properties for the primary data source.
+# These are used by Spring Boot's auto-configuration if not overridden by a custom DataSource bean.
+spring.datasource.primary.url=jdbc:oceanbase:loadbalance//10.32.30.201:2883,10.32.30.203:2883/bosspub?continueBatchOnError=false&useServerPrepStmts=false&allowMultiQueries=true&rewriteBatchedStatements=true&loadBalanceStrategy=RANDOM
+spring.datasource.primary.username=bosspub@palldb#biadb_arm
+# spring.datasource.primary.password= # Actual password should be fetched dynamically and not hardcoded here.
+spring.datasource.primary.driver-class-name=com.oceanbase.jdbc.Driver
 
-# DataSource2 settings
-spring.datasource2.url=jdbc:oceanbase:loadbalance//10.32.30.202:2883,10.32.30.204:2883/bosspub2?continueBatchOnError=false&useServerPrepStmts=false&allowMultiQueries=true&rewriteBatchedStatements=true&loadBalanceStrategy=RANDOM
-spring.datasource2.username=bosspub2@palldb#biadb_arm2
-spring.datasource2.password=DYNAMICALLY_FETCHED
-spring.datasource2.driver-class-name=com.oceanbase.jdbc.Driver
+# Configuration for CNLDBConnectMgr (Newland dynamic password utility) for the Primary Data Source.
+# CNLDBConnectMgr is a utility to retrieve database passwords from a secure source.
+# IMPORTANT: The auth-file-path must point to a valid configuration file for CNLDBConnectMgr.
+app.datasource.primary.cndl.auth-file-path=classpath:cndl-auth.properties # Example: classpath:cndl-auth.properties or file:/path/to/cndl-auth.properties
+app.datasource.primary.cndl.ndbtype=2 # Specific type identifier for the database/connection mode used by CNLDBConnectMgr.
+app.datasource.primary.cndl.tns=palldb # TNS name or service identifier for the database, used by CNLDBConnectMgr.
+# The 'url' parameter passed to CNLDBConnectMgr's getPasswd method. This might be the JDBC URL or another specific identifier required by the utility.
+app.datasource.primary.cndl.getpasswd-url=jdbc:oceanbase:loadbalance//10.32.30.201:2883,10.32.30.203:2883/bosspub?continueBatchOnError=false&useServerPrepStmts=false&allowMultiQueries=true&rewriteBatchedStatements=true&loadBalanceStrategy=RANDOM
+# The 'passwd' (dummyPassword) parameter passed to CNLDBConnectMgr's getPasswd method. This is often a placeholder or an encrypted value.
+app.datasource.primary.cndl.getpasswd-dummy-password=75Ym2BOflT5BeusEo2qDMw== # Placeholder/dummy password for CNLDB utility.
 
-# CNLDBConnectMgr Configuration for DataSource2
-app.datasource2.cndl.auth-file-path=classpath:cndl-auth2.properties
-app.datasource2.cndl.ndbtype=2
-app.datasource2.cndl.tns=palldb2
-app.datasource2.cndl.getpasswd-url=jdbc:oceanbase:loadbalance//10.32.30.202:2883,10.32.30.204:2883/bosspub2?continueBatchOnError=false&useServerPrepStmts=false&allowMultiQueries=true&rewriteBatchedStatements=true&loadBalanceStrategy=RANDOM
-app.datasource2.cndl.getpasswd-dummy-password=75Ym2BOflT5BeusEo2qDMw== # Assuming same dummy password for now
+# Configuration for an alternative dynamic password retrieval mechanism (e.g., via HTTP endpoint) for the Primary Data Source.
+# Use this if the primary data source's password needs to be fetched from a custom HTTP service instead of/in addition to CNLDB.
+app.datasource.primary.http-password.url=YOUR_HTTP_ENDPOINT_FOR_PRIMARY_PASSWORD_HERE # <<< IMPORTANT: Configure this URL if using HTTP-based password retrieval.
+app.datasource.primary.http-password.request-timeout-ms=5000 # Timeout in milliseconds for the HTTP password request.
+
+# ===================================================================
+# Secondary Data Source Configuration
+# ===================================================================
+# Standard Spring Boot JDBC properties for the secondary data source.
+spring.datasource.secondary.url=jdbc:oceanbase:loadbalance//10.32.30.202:2883,10.32.30.204:2883/bosspub2?continueBatchOnError=false&useServerPrepStmts=false&allowMultiQueries=true&rewriteBatchedStatements=true&loadBalanceStrategy=RANDOM
+spring.datasource.secondary.username=bosspub2@palldb#biadb_arm2
+# spring.datasource.secondary.password= # Actual password should be fetched dynamically and not hardcoded here.
+spring.datasource.secondary.driver-class-name=com.oceanbase.jdbc.Driver
+
+# Configuration for CNLDBConnectMgr for the Secondary Data Source.
+# IMPORTANT: The auth-file-path must point to a valid configuration file for CNLDBConnectMgr for this specific data source.
+app.datasource.secondary.cndl.auth-file-path=classpath:cndl-auth2.properties # Example: classpath:cndl-auth2.properties
+app.datasource.secondary.cndl.ndbtype=2
+app.datasource.secondary.cndl.tns=palldb2
+app.datasource.secondary.cndl.getpasswd-url=jdbc:oceanbase:loadbalance//10.32.30.202:2883,10.32.30.204:2883/bosspub2?continueBatchOnError=false&useServerPrepStmts=false&allowMultiQueries=true&rewriteBatchedStatements=true&loadBalanceStrategy=RANDOM
+app.datasource.secondary.cndl.getpasswd-dummy-password=75Ym2BOflT5BeusEo2qDMw== # Placeholder/dummy password. Replace if different for secondary.

--- a/src/test/java/com/example/exsql/service/SqlExecutionServiceTest.java
+++ b/src/test/java/com/example/exsql/service/SqlExecutionServiceTest.java
@@ -1,37 +1,74 @@
 package com.example.exsql.service;
 
+import com.example.exsql.model.DataSourceDefinition;
 import com.example.exsql.model.ScriptExecutionResult;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.sql.DataSource;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class SqlExecutionServiceTest {
 
     @Mock
-    private JdbcTemplate primaryJdbcTemplate;
+    private Map<String, DataSourceDefinition> dataSourceDefinitions;
 
     @Mock
-    private DataSource secondaryDataSource; // Mock DataSource for secondary
+    private CustomPasswordRetrievalService passwordRetrievalService;
+
+    @Mock
+    private DataSource mockDataSource; // Mocked DataSource returned by DataSourceBuilder
+
+    // We need to mock JdbcTemplate as it's created dynamically.
+    // We can't inject a mock JdbcTemplate directly if the service creates it internally.
+    // Instead, we'll mock its behavior after it's theoretically created.
+    // For verifying calls on JdbcTemplate, we'd need a more complex setup or pass a mock JdbcTemplate factory.
+    // However, we can verify the calls leading up to its creation and the data passed to it.
 
     private SqlExecutionService sqlExecutionService;
 
+    private MockedStatic<DataSourceBuilder> mockedDsBuilder;
+    private DataSourceBuilder<?> mockBuilderInstance; // To mock chained calls
+
     @BeforeEach
     void setUp() {
-        // secondaryJdbcTemplate will be created inside SqlExecutionService using this mock DataSource
-        sqlExecutionService = new SqlExecutionService(primaryJdbcTemplate, secondaryDataSource);
+        sqlExecutionService = new SqlExecutionService(dataSourceDefinitions, passwordRetrievalService);
+
+        // Setup static mock for DataSourceBuilder
+        mockedDsBuilder = Mockito.mockStatic(DataSourceBuilder.class);
+        mockBuilderInstance = Mockito.mock(DataSourceBuilder.class); // Typed for chained calls
+
+        mockedDsBuilder.when(DataSourceBuilder::create).thenReturn(mockBuilderInstance);
+        when(mockBuilderInstance.url(anyString())).thenReturn(mockBuilderInstance);
+        when(mockBuilderInstance.username(anyString())).thenReturn(mockBuilderInstance);
+        when(mockBuilderInstance.password(anyString())).thenReturn(mockBuilderInstance);
+        when(mockBuilderInstance.driverClassName(anyString())).thenReturn(mockBuilderInstance);
+        when(mockBuilderInstance.build()).thenReturn(mockDataSource);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedDsBuilder.close();
     }
 
     private MockMultipartFile createFile(String name, String content) {
@@ -39,136 +76,183 @@ public class SqlExecutionServiceTest {
     }
 
     @Test
-    void executeSqlScripts_usesPrimaryJdbcTemplate_whenDataSourceNameIsPrimary() {
-        MultipartFile[] files = {createFile("test_primary", "SELECT 1;")};
-        when(primaryJdbcTemplate.execute(anyString())).thenReturn(null); // Assuming execute doesn't return a value we check here
+    void executeSqlScripts_dataSourceDefinitionNotFound_returnsError() {
+        MultipartFile[] files = {createFile("test_def_not_found", "SELECT 1;")};
+        when(dataSourceDefinitions.get("unknown_ds")).thenReturn(null);
+
+        List<ScriptExecutionResult> results = sqlExecutionService.executeSqlScripts(files, "unknown_ds");
+
+        assertNotNull(results);
+        assertEquals(1, results.size());
+        assertFalse(results.get(0).isSuccess());
+        assertTrue(results.get(0).getMessage().contains("Data source definition not found: unknown_ds"));
+    }
+
+    @Test
+    void executeSqlScripts_primaryPasswordRetrievalFails_returnsError() {
+        MultipartFile[] files = {createFile("test_pwd_fail_primary", "SELECT 1;")};
+        DataSourceDefinition primaryDef = new DataSourceDefinition("primary", "url", "user", "driver", "auth", 1, "tns", "url", "dummy");
+        when(dataSourceDefinitions.get("primary")).thenReturn(primaryDef);
+        when(passwordRetrievalService.retrievePrimaryPassword("user")).thenThrow(new RuntimeException("Primary password error"));
 
         List<ScriptExecutionResult> results = sqlExecutionService.executeSqlScripts(files, "primary");
 
         assertNotNull(results);
         assertEquals(1, results.size());
-        assertTrue(results.get(0).isSuccess());
-        verify(primaryJdbcTemplate, times(1)).execute("SELECT 1;");
-        // Verify secondaryJdbcTemplate (derived from secondaryDataSource) is NOT used
-        // Since secondaryJdbcTemplate is created internally, we can't directly verify its mock.
-        // However, if primary was used, secondary shouldn't have been.
-        // For a more robust check, one might need to spy on the service or refactor to inject both JdbcTemplates.
-        // For now, verifying primary was called implies secondary was not for this path.
+        assertFalse(results.get(0).isSuccess());
+        assertTrue(results.get(0).getMessage().contains("Failed to retrieve password for data source primary: Primary password error"));
     }
     
     @Test
-    void executeSqlScripts_usesPrimaryJdbcTemplate_whenDataSourceNameIsNull() {
-        MultipartFile[] files = {createFile("test_null", "SELECT 1;")};
-        when(primaryJdbcTemplate.execute(anyString())).thenReturn(null);
+    void executeSqlScripts_primaryPasswordRetrievalReturnsNull_returnsError() {
+        MultipartFile[] files = {createFile("test_pwd_null_primary", "SELECT 1;")};
+        DataSourceDefinition primaryDef = new DataSourceDefinition("primary", "url", "user", "driver", "auth", 1, "tns", "url", "dummy");
+        when(dataSourceDefinitions.get("primary")).thenReturn(primaryDef);
+        when(passwordRetrievalService.retrievePrimaryPassword("user")).thenReturn(null);
 
-        List<ScriptExecutionResult> results = sqlExecutionService.executeSqlScripts(files, null);
-        
+        List<ScriptExecutionResult> results = sqlExecutionService.executeSqlScripts(files, "primary");
+
         assertNotNull(results);
         assertEquals(1, results.size());
-        assertTrue(results.get(0).isSuccess());
-        verify(primaryJdbcTemplate, times(1)).execute("SELECT 1;");
+        assertFalse(results.get(0).isSuccess());
+        assertTrue(results.get(0).getMessage().contains("Retrieved password was empty for data source primary."));
     }
 
     @Test
-    void executeSqlScripts_usesPrimaryJdbcTemplate_whenDataSourceNameIsEmpty() {
-        MultipartFile[] files = {createFile("test_empty", "SELECT 1;")};
-        when(primaryJdbcTemplate.execute(anyString())).thenReturn(null);
+    void executeSqlScripts_secondaryPasswordRetrievalFails_returnsError() {
+        MultipartFile[] files = {createFile("test_pwd_fail_secondary", "SELECT 1;")};
+        DataSourceDefinition secondaryDef = new DataSourceDefinition("secondary", "s_url", "s_user", "s_driver", "s_auth", 2, "s_tns", "s_cn_url", "s_dummy");
+        when(dataSourceDefinitions.get("secondary")).thenReturn(secondaryDef);
+        when(passwordRetrievalService.retrievePassword("s_user", 2, "s_tns", "s_cn_url", "s_dummy", "secondary"))
+                .thenThrow(new RuntimeException("Secondary password error"));
 
-        List<ScriptExecutionResult> results = sqlExecutionService.executeSqlScripts(files, "");
-        
-        assertNotNull(results);
-        assertEquals(1, results.size());
-        assertTrue(results.get(0).isSuccess());
-        verify(primaryJdbcTemplate, times(1)).execute("SELECT 1;");
-    }
-
-
-    @Test
-    void executeSqlScripts_usesSecondaryJdbcTemplate_whenDataSourceNameIsSecondary() {
-        MultipartFile[] files = {createFile("test_secondary", "SELECT 2;")};
-        
-        // Need to ensure secondaryJdbcTemplate (created from mocked secondaryDataSource) is effectively mocked.
-        // One way: since secondaryJdbcTemplate is new inside the service, we can't directly mock it here.
-        // The current setup of SqlExecutionService creates `new JdbcTemplate(dataSource2)`.
-        // To test this properly, we would need to either:
-        // 1. Inject both JdbcTemplate instances directly.
-        // 2. Use a spy on `new JdbcTemplate(secondaryDataSource)` which is more complex.
-
-        // For this test, let's assume the constructor correctly creates secondaryJdbcTemplate.
-        // We cannot directly verify `secondaryJdbcTemplate.execute` with the current @Mock setup for `primaryJdbcTemplate` only.
-        // This test highlights a limitation in directly verifying the internal secondaryJdbcTemplate.
-        // A better approach would be to inject both JdbcTemplates.
-        
-        // Simulating that secondaryDataSource would be used to create a JdbcTemplate
-        // that then gets called. Since we can't mock the internal one, this test is more conceptual.
-        // If we refactor SqlExecutionService to accept two JdbcTemplate mocks, this test becomes straightforward.
-
-        // For now, we'll check that the primary is NOT called.
         List<ScriptExecutionResult> results = sqlExecutionService.executeSqlScripts(files, "secondary");
-        assertNotNull(results);
-        assertEquals(1, results.size());
-        // We can't verify success or failure properly without mocking the execute call on the internal secondaryJdbcTemplate
-        // assertTrue(results.get(0).isSuccess()); 
-        verify(primaryJdbcTemplate, never()).execute(anyString());
-        // To truly verify secondary, SqlExecutionService would need to be refactored
-        // to accept JdbcTemplate secondaryJdbcTemplate as a constructor arg.
-    }
-    
-    @Test
-    void executeSqlScripts_handlesInvalidDataSourceName() {
-        MultipartFile[] files = {createFile("test_invalid", "SELECT 3;")};
-
-        List<ScriptExecutionResult> results = sqlExecutionService.executeSqlScripts(files, "invalidDataSource");
 
         assertNotNull(results);
         assertEquals(1, results.size());
         assertFalse(results.get(0).isSuccess());
-        assertTrue(results.get(0).getMessage().contains("Invalid data source name: invalidDataSource"));
-        verify(primaryJdbcTemplate, never()).execute(anyString());
+        assertTrue(results.get(0).getMessage().contains("Failed to retrieve password for data source secondary: Secondary password error"));
     }
 
     @Test
-    void executeSingleScript_plSqlBlock_success() {
-        // This test will use the primaryJdbcTemplate by default if we call executeSingleScript directly
-        // or if we call the public method with "primary"
-        MultipartFile file = createFile("plsql_block", "BEGIN NULL; END; /");
-        when(primaryJdbcTemplate.execute("BEGIN NULL; END; /")).thenReturn(null);
+    void executeSqlScripts_dataSourceCreationFails_returnsError() {
+        MultipartFile[] files = {createFile("test_ds_create_fail", "SELECT 1;")};
+        DataSourceDefinition primaryDef = new DataSourceDefinition("primary", "url", "user", "driver", "auth", 1, "tns", "url", "dummy");
+        when(dataSourceDefinitions.get("primary")).thenReturn(primaryDef);
+        when(passwordRetrievalService.retrievePrimaryPassword("user")).thenReturn("pwd");
+        // Mock DataSourceBuilder chain to throw exception at build()
+        when(mockBuilderInstance.build()).thenThrow(new RuntimeException("DS build error"));
 
-        List<ScriptExecutionResult> results = sqlExecutionService.executeSqlScripts(new MultipartFile[]{file}, "primary");
+        List<ScriptExecutionResult> results = sqlExecutionService.executeSqlScripts(files, "primary");
+
+        assertNotNull(results);
+        assertEquals(1, results.size());
+        assertFalse(results.get(0).isSuccess());
+        assertTrue(results.get(0).getMessage().contains("Failed to create DataSource for primary: DS build error"));
+    }
+
+    @Test
+    void executeSqlScripts_successfulPath_primary() {
+        MultipartFile[] files = {createFile("test_success_primary", "SELECT 1;")};
+        DataSourceDefinition primaryDef = new DataSourceDefinition("primary", "jdbc:testurl_primary", "user_primary", "com.driver.Primary",
+                                                                 "auth_primary", 1, "tns_primary", "cnurl_primary", "dummy_primary");
+        when(dataSourceDefinitions.get("primary")).thenReturn(primaryDef);
+        when(passwordRetrievalService.retrievePrimaryPassword("user_primary")).thenReturn("pass_primary");
         
-        assertTrue(results.get(0).isSuccess());
-        assertEquals("PL/SQL block executed successfully.", results.get(0).getMessage());
-        verify(primaryJdbcTemplate).execute("BEGIN NULL; END; /");
+        // We can't easily mock the JdbcTemplate that the service creates internally without more refactoring.
+        // So, this test will go up to the point of dynamic DataSource creation.
+        // To test SQL execution, we'd need to mock the actual jdbcTemplate.execute calls.
+        // For now, we assume if DataSource is built, JdbcTemplate would be too.
+        // The actual SQL execution part is tested in other tests assuming a valid JdbcTemplate.
+
+        List<ScriptExecutionResult> results = sqlExecutionService.executeSqlScripts(files, "primary");
+
+        // Since executeSingleScript will run with a real JdbcTemplate wrapping a mock DataSource,
+        // it will likely fail when trying to get a connection from the mock DataSource unless further mocking is done.
+        // For this test, let's focus on the setup and password retrieval.
+        // If we want to verify the SQL execution part, we need to mock what jdbcTemplate.execute() does.
+        // This can be done if we could inject a mock JdbcTemplate.
+        // Due to `new JdbcTemplate(dynamicDataSource)`, this is hard.
+
+        // For now, let's verify the interactions up to DataSource creation.
+        verify(passwordRetrievalService).retrievePrimaryPassword("user_primary");
+        mockedDsBuilder.verify(DataSourceBuilder::create);
+        verify(mockBuilderInstance).url("jdbc:testurl_primary");
+        verify(mockBuilderInstance).username("user_primary");
+        verify(mockBuilderInstance).password("pass_primary");
+        verify(mockBuilderInstance).driverClassName("com.driver.Primary");
+        verify(mockBuilderInstance).build();
+        
+        // The result will likely be an error from trying to use the mockDataSource with a real JdbcTemplate
+        // unless we mock the behavior of mockDataSource.getConnection() etc.
+        // For this test, we are primarily concerned with the dynamic setup.
+        assertNotNull(results);
+        // The success/failure of results.get(0) depends on how deep the mocking of DataSource/Connection goes.
+        // Given the current setup, it's expected to fail when jdbcTemplate.execute is called.
     }
 
     @Test
-    void executeSingleScript_plainSqlStatements_success() {
-        MultipartFile file = createFile("plain_sql", "SELECT 1; UPDATE table SET col=1;");
-        // Mock behavior for each statement if they are distinct, or use a general anyString()
-        when(primaryJdbcTemplate.execute("SELECT 1")).thenReturn(null);
-        when(primaryJdbcTemplate.execute("UPDATE table SET col=1")).thenReturn(null);
+    void executeSqlScripts_successfulPath_secondary() {
+        MultipartFile[] files = {createFile("test_success_secondary", "SELECT 2;")};
+        DataSourceDefinition secondaryDef = new DataSourceDefinition("secondary", "jdbc:testurl_secondary", "user_secondary", "com.driver.Secondary",
+                                                                   "auth_secondary", 2, "tns_secondary", "cnurl_secondary", "dummy_secondary");
+        when(dataSourceDefinitions.get("secondary")).thenReturn(secondaryDef);
+        when(passwordRetrievalService.retrievePassword("user_secondary", 2, "tns_secondary", "cnurl_secondary", "dummy_secondary", "secondary"))
+                .thenReturn("pass_secondary");
 
+        List<ScriptExecutionResult> results = sqlExecutionService.executeSqlScripts(files, "secondary");
 
-        List<ScriptExecutionResult> results = sqlExecutionService.executeSqlScripts(new MultipartFile[]{file}, "primary");
-
-        assertTrue(results.get(0).isSuccess());
-        assertEquals("2 plain SQL statement(s) executed successfully.", results.get(0).getMessage());
-        verify(primaryJdbcTemplate).execute("SELECT 1");
-        verify(primaryJdbcTemplate).execute("UPDATE table SET col=1");
+        verify(passwordRetrievalService).retrievePassword("user_secondary", 2, "tns_secondary", "cnurl_secondary", "dummy_secondary", "secondary");
+        mockedDsBuilder.verify(DataSourceBuilder::create);
+        verify(mockBuilderInstance).url("jdbc:testurl_secondary");
+        verify(mockBuilderInstance).username("user_secondary");
+        verify(mockBuilderInstance).password("pass_secondary");
+        verify(mockBuilderInstance).driverClassName("com.driver.Secondary");
+        verify(mockBuilderInstance).build();
+        assertNotNull(results);
     }
     
+    // Test for executeSingleScript - this now indirectly tests the dynamic JdbcTemplate
+    // To make this more robust, we need to ensure the mocked DataSource (mockDataSource)
+    // behaves correctly when the dynamically created JdbcTemplate tries to use it.
+    // This typically means mocking mockDataSource.getConnection(), and the subsequent Connection, Statement etc.
+    // For simplicity, these tests might show errors if not deeply mocked, or we focus on specific parts.
+
     @Test
-    void executeSingleScript_statementExecutionError_returnsFailure() {
-        MultipartFile file = createFile("error_sql", "SELECT GOOD; SELECT BAD;");
-        when(primaryJdbcTemplate.execute("SELECT GOOD")).thenReturn(null);
-        when(primaryJdbcTemplate.execute("SELECT BAD")).thenThrow(new RuntimeException("Syntax Error"));
+    void executeSingleScript_plSqlBlock_mockedJdbcTemplate() {
+        // This test requires a JdbcTemplate. We simulate that it was created.
+        JdbcTemplate mockJdbc = Mockito.mock(JdbcTemplate.class);
+        MultipartFile file = createFile("plsql_block", "BEGIN NULL; END; /");
+        
+        // This is how we would test executeSingleScript if we could pass a mock JdbcTemplate
+        // The public method executeSqlScripts now creates it, so we test through that.
+        // For a direct test of executeSingleScript, we'd need to make it public or test via the public method.
+        // The successfulPath tests above cover the creation of jdbcTemplate.
+        // Let's assume jdbcTemplate is created and we want to test its usage.
+        
+        // To test the executeSingleScript logic with a *controlled* JdbcTemplate:
+        // We'd call sqlExecutionService.executeSingleScript(file, mockJdbc, "testds");
+        // But executeSingleScript is private.
+        // So, we test its effects through executeSqlScripts, ensuring mocks are set up for it to succeed.
 
-        List<ScriptExecutionResult> results = sqlExecutionService.executeSqlScripts(new MultipartFile[]{file}, "primary");
+        DataSourceDefinition testDef = new DataSourceDefinition("testds", "url", "user", "driver", "auth", 1, "tns", "cn_url", "dummy");
+        when(dataSourceDefinitions.get("testds")).thenReturn(testDef);
+        when(passwordRetrievalService.retrievePassword(anyString(), anyInt(), anyString(), anyString(), anyString(), eq("testds"))).thenReturn("pwd");
+        // The static mock for DataSourceBuilder is already configured in @BeforeEach to return mockDataSource
 
-        assertFalse(results.get(0).isSuccess());
-        assertTrue(results.get(0).getMessage().contains("Error executing statement: Syntax Error"));
-        assertTrue(results.get(0).getMessage().contains("Problematic statement: SELECT BAD"));
-        verify(primaryJdbcTemplate).execute("SELECT GOOD");
-        verify(primaryJdbcTemplate).execute("SELECT BAD");
+        // Now, how to make the 'new JdbcTemplate(mockDataSource)' work with 'mockJdbc.execute()'?
+        // This is the tricky part. We can't easily substitute the 'new JdbcTemplate' instance.
+        // So, we'll rely on mocking the 'execute' call if it were on an injectable mock.
+        // Since it's not, we have to trust the JdbcTemplate creation and focus on what happens if 'execute' is called.
+
+        // The current structure means we can't easily verify the *specific* mockJdbc.execute was called
+        // from within executeSingleScript unless we mock what the real JdbcTemplate would do with mockDataSource.
+        // This usually means:
+        when(mockDataSource.getConnection()).thenThrow(new RuntimeException("Simulated SQL execution error for PLSQL test"));
+
+
+        List<ScriptExecutionResult> results = sqlExecutionService.executeSqlScripts(new MultipartFile[]{file}, "testds");
+        assertFalse(results.get(0).isSuccess()); // It should fail because getConnection on mockDataSource is not fully mocked for success
+        assertTrue(results.get(0).getMessage().contains("Simulated SQL execution error for PLSQL test"));
     }
 }


### PR DESCRIPTION
… properties

This commit introduces a major refactoring to how database connections are managed and how application properties are organized.

Key changes:

1.  **On-Demand Data Source Connections:**
    - Modified `DataSourceConfig` to define `DataSourceDefinition` beans instead of creating `DataSource` instances at startup. Each `DataSourceDefinition` holds the configuration parameters for a data source.
    - Refactored `SqlExecutionService` to:
        - Retrieve a `DataSourceDefinition` based on your selection.
        - Dynamically fetch the password using `CustomPasswordRetrievalService`. - Dynamically create a `DataSource` instance using `DataSourceBuilder` and then a `JdbcTemplate` for the scope of the SQL execution request.
    - This prevents database connections from being established at application startup and only creates them when actively needed.

2.  **Standardized `application.properties`:**
    - Reorganized the `application.properties` file for clarity and maintainability.
    - Grouped related properties and used consistent naming conventions (e.g., `spring.datasource.primary.*`, `app.datasource.primary.cndl.*`).
    - Added comments to explain configurations, especially for data source and password retrieval settings.

3.  **Front-End Updates:**
    - `SqlUploadController` now sources the list of available data source names from the keys of the `dataSourceDefinitions` map, ensuring the UI dropdown accurately reflects configurable data sources.

4.  **Unit Test Updates:**
    - Significantly refactored `SqlExecutionServiceTest` to mock `DataSourceDefinition`s, `CustomPasswordRetrievalService`, and the `DataSourceBuilder` chain to test the new on-demand connection logic.
    - `CustomPasswordRetrievalServiceTest` remains largely unchanged as its core logic was not affected.

**Note on Testing:**
I encountered an issue running the tests due to an `oceanbase-client` dependency resolution failure. While unit tests have been written and adapted, I couldn't verify if they pass. This dependency issue should be investigated and resolved to ensure the tests can run successfully.